### PR TITLE
Ignore Errno::EPIPE if STDOUT is closed early

### DIFF
--- a/bin/jsonpp
+++ b/bin/jsonpp
@@ -183,6 +183,7 @@ def main(file_path)
 rescue OkJson::Error, OkJson::Utf8Error => ex
   $stderr.puts ex
   exit 1
+rescue Errno::EPIPE
 end
 
 main(ARGV[0])


### PR DESCRIPTION
When piping `jsonpp` into `less`, exiting `less` will cause an `Errno::EPIPE` exception and annoying backtrace.
